### PR TITLE
Fix patch for heap byte buffer access

### DIFF
--- a/finagle-native/tomcat-native-1.1.22.finagle.patch
+++ b/finagle-native/tomcat-native-1.1.22.finagle.patch
@@ -456,7 +456,7 @@ index 0000000..186bd2f
 +                    throw new RuntimeException("Buffer pool write overflow");
 +
 +                if (src.hasArray()) {
-+                    buffer.put(src.array(), src.position(), len);
++                    buffer.put(src.array(), src.arrayOffset() + src.position(), len);
 +                } else {
 +                    int pos = src.position();
 +                    int lim = src.limit();
@@ -489,7 +489,7 @@ index 0000000..186bd2f
 +                    throw new RuntimeException("Buffer pool write overflow");
 +
 +                if (src.hasArray()) {
-+                    buffer.put(src.array(), src.position(), len);
++                    buffer.put(src.array(), src.arrayOffset() + src.position(), len);
 +                } else {
 +                    int pos = src.position();
 +                    int lim = src.limit();
@@ -521,7 +521,7 @@ index 0000000..186bd2f
 +                if (sslRead > 0) {
 +                    read.set(sslRead);
 +                    if (dst.hasArray()) {
-+                        buffer.get(dst.array(), dst.position(), sslRead);
++                        buffer.get(dst.array(), dst.arrayOffset() + dst.position(), sslRead);
 +                        dst.position(dst.position() + sslRead);
 +                    } else {
 +                        int lim = buffer.limit();


### PR DESCRIPTION
Reading from a heap `ByteBuffer` was broken, since we were not taking the array offset into account. This was previously fine, but new netty sends buffers with non-zero offsets, so now we have to fix it. This patch changes every location where we call `ByteBuffer.array()` to also account for the array offset.

@katfang please review / merge. 

Note that I have already used this to generate version 1.1.17-Firebase-4 of the tomcat-native jar, but the PR to actually use that is not yet merged.
